### PR TITLE
Use published contract-proxy-kit

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,6 +21,6 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-cla-document: 'https://github.com/gnosis/contract-proxy-kit/blob/master/GNOSISCLA.md'
           branch: 'cla-signatures'
-          allowlist: germartinez,mikheevm,rmeissner,Uxio0,dasanra,davidalbela,luarx,giacomolicari,lukasschor,tschubotz,gnosis-info,bot*
+          allowlist: germartinez,mikheevm,rmeissner,Uxio0,dasanra,davidalbela,luarx,giacomolicari,lukasschor,tschubotz,fmrsabino,gnosis-info,bot*
           empty-commit-flag: false
           blockchain-storage-flag: false

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 In the project directory, you can run:
 
+### `yarn install`
+
+Installs the required dependencies declared in `package.json`.
+
 ### `yarn start`
 
 Runs the app in the development mode.<br />

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/styled-components": "^5.1.7",
     "@walletconnect/web3-provider": "^1.3.6",
     "bignumber.js": "^9.0.1",
-    "contract-proxy-kit": "../contract-proxy-kit",
+    "contract-proxy-kit": "^3.0.0",
     "gh-pages": "^3.1.0",
     "keccak256": "^1.0.2",
     "prettier": "^2.2.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "lib": [
       "es6",
       "dom"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4485,14 +4485,17 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-contract-proxy-kit@../contract-proxy-kit:
-  version "2.2.0-alpha.3"
+contract-proxy-kit@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/contract-proxy-kit/-/contract-proxy-kit-3.0.0.tgz#5e6fb1ca874a3bbf45b5c21dcdd6d514569c19d0"
+  integrity sha512-w/HgsqJWT81qLwyEg4xfY3xIxtQzu2cN8e9njlcK8OLZmE5yGrwfH0iZCWSOZyvhlhZGm5bqtBslkb1ZtEfbdw==
   dependencies:
     "@gnosis.pm/safe-apps-sdk" "^1.1.0"
     "@truffle/contract" "^4.3.6"
     "@types/uuid" "^8.3.0"
     bignumber.js "^9.0.1"
     ethereumjs-util "^7.0.7"
+    ethers "4.0.45"
     node-fetch "^2.6.1"
     uuid "^8.3.2"
 
@@ -5448,6 +5451,19 @@ electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.649:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.662.tgz#43305bcf88a3340feb553b815d6fd7466659d5ee"
   integrity sha512-IGBXmTGwdVGUVTnZ8ISEvkhDfhhD+CDFndG4//BhvDcEtPYiVrzoB+rzT/Y12OQCf5bvRCrVmrUbGrS9P7a6FQ==
 
+elliptic@6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
+  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
+
 elliptic@6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
@@ -6306,6 +6322,21 @@ ethereumjs-vm@^2.3.4, ethereumjs-vm@^2.6.0:
     merkle-patricia-tree "^2.3.2"
     rustbn.js "~0.2.0"
     safe-buffer "^5.1.1"
+
+ethers@4.0.45:
+  version "4.0.45"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.45.tgz#8d4cd764d7c7690836b583d4849203c225eb56e2"
+  integrity sha512-N/Wmc6Mw4pQO+Sss1HnKDCSS6KSCx0luoBMiPNq+1GbOaO3YaZOyplBEhj+NEoYsizZYODtkITg2oecPeNnidQ==
+  dependencies:
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.5.2"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
 
 ethers@^4.0.0-beta.1, ethers@^4.0.32, ethers@^4.0.36:
   version "4.0.48"


### PR DESCRIPTION
- Use published `contract-proxy-kit` artifact (instead of using the one in the local path)
- Update `Readme.md` with the installation step